### PR TITLE
feat(frontend): @aiharanaoya/ui を導入してフォームコンポーネントを置き換え

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: latest
           cache: pnpm
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - run: pnpm i
       - run: pnpm build
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@aiharanaoya:registry=https://npm.pkg.github.com

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,6 +9,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@aiharanaoya/ui": "0.0.2",
 		"@app/backend": "workspace:*",
 		"@tanstack/react-query": "5.99.2",
 		"@tanstack/react-router": "1.168.23",

--- a/apps/frontend/src/components/MessageForm.tsx
+++ b/apps/frontend/src/components/MessageForm.tsx
@@ -1,3 +1,4 @@
+import { Button, Input } from '@aiharanaoya/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { type FC, type FormEvent, useState } from 'react';
 import { api } from '@/lib/api';
@@ -46,12 +47,11 @@ export const MessageForm: FC = () => {
 				>
 					名前
 				</label>
-				<input
+				<Input
 					type="text"
 					id="author"
 					value={author}
 					onChange={(e) => setAuthor(e.target.value)}
-					className="w-full text-base leading-relaxed px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-gray-900"
 					placeholder="あなたの名前を入力"
 					required
 				/>
@@ -73,14 +73,16 @@ export const MessageForm: FC = () => {
 					required
 				/>
 			</div>
-			<button
+			<Button
 				type="submit"
+				variant="primary"
+				size="lg"
 				disabled={mutation.isPending}
-				className="w-full text-base font-medium leading-relaxed bg-gray-900 text-white px-6 py-3 rounded-md hover:bg-gray-800 transition-colors flex items-center justify-center gap-2"
+				style={{ width: '100%' }}
 			>
 				<span>📤</span>
 				{mutation.isPending ? '投稿中...' : '投稿する'}
-			</button>
+			</Button>
 		</form>
 	);
 };

--- a/apps/frontend/src/style.css
+++ b/apps/frontend/src/style.css
@@ -1,1 +1,2 @@
+@import "@aiharanaoya/ui/styles";
 @import "tailwindcss";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@aiharanaoya/ui':
+        specifier: 0.0.2
+        version: 0.0.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@app/backend':
         specifier: workspace:*
         version: link:../backend
@@ -90,6 +93,12 @@ importers:
         version: 8.0.8(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
 
 packages:
+
+  '@aiharanaoya/ui@0.0.2':
+    resolution: {integrity: sha512-EGdu17sSMygNGQDMrDq7UfcUyuKXTyhvbgN6pu7xNpCFgAhsvJV26YxZ99mreL61tePJXw8c1BRVZGzc6Y8e1w==, tarball: https://npm.pkg.github.com/download/@aiharanaoya/ui/0.0.2/4b2aa0490f7d0b1138dab701f1d747be1e75a35d}
+    peerDependencies:
+      react: ^19
+      react-dom: ^19
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1429,6 +1438,11 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@aiharanaoya/ui@0.0.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,5 @@ onlyBuiltDependencies:
 managePackageManagerVersions: true
 saveExact: true
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@aiharanaoya/ui"


### PR DESCRIPTION
## Overview

- `@aiharanaoya/ui` を GitHub Packages からインストールし、フロントエンドに導入した
- `MessageForm.tsx` の `<input>` を `<Input>`、`<button>` を `<Button variant="primary">` に置き換えた
- `style.css` に `@aiharanaoya/ui/styles` をインポートしてデザイントークンとコンポーネントスタイルを適用した
- `pnpm-workspace.yaml` に `minimumReleaseAgeExclude` を追加し、公開直後のパッケージもインストールできるようにした
- `.npmrc` に GitHub Packages のレジストリ設定を追加した