### PR TITLE
chore(ci): Renovate に GitHub Packages の認証設定を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
+	"npmrc": "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}",
 	"lockFileMaintenance": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Overview

- Renovate が lockfile を更新する際に `@aiharanaoya/ui`（GitHub Packages）へのアクセスで 401 エラーが発生していた
- `renovate.json` に `npmrc` を追加し、`GITHUB_TOKEN` を使って GitHub Packages を認証できるようにした