### PR TITLE
chore(ci): Renovate の GitHub Packages 認証を hostRules に変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,12 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
-	"npmrc": "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}",
+	"hostRules": [
+		{
+			"matchHost": "npm.pkg.github.com",
+			"hostType": "npm"
+		}
+	],
 	"lockFileMaintenance": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Overview

- `npmrc` に `${GITHUB_TOKEN}` を書く方式では Renovate 実行時に環境変数が展開されず 401 エラーになっていた
- Renovate ネイティブの `hostRules` に変更し、Renovate 自身の GitHub インストールトークンで `npm.pkg.github.com` を認証するようにした