### PR TITLE
chore(ci): Renovate を GitHub Actions に移行

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,17 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN
+          }}">>~/.npmrc
+      - uses: renovatebot/github-action@v46.1.12
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN
-          }}">>~/.npmrc
+      - run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - uses: renovatebot/github-action@v46.1.12
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
-	"hostRules": [
-		{
-			"matchHost": "npm.pkg.github.com",
-			"hostType": "npm"
-		}
-	],
 	"lockFileMaintenance": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Overview

- Mend hosted Renovate App では GitHub Packages（`@aiharanaoya/ui`）への認証ができず、lockfile の更新に失敗していた
- GitHub Actions で Renovate を動かすことで `GITHUB_TOKEN` を渡せるようにした
- 不要になった `hostRules` を `renovate.json` から削除した

マージ後、Mend の Renovate App をリポジトリからアンインストールすること。