### PR TITLE
fix(ci): Renovate の GitHub Packages 認証を RENOVATE_SECRETS 経由に修正

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - uses: renovatebot/github-action@v46.1.12
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_SECRETS: '{"GITHUB_NPM_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}'

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
+	"hostRules": [
+		{
+			"matchHost": "npm.pkg.github.com",
+			"hostType": "npm",
+			"token": "{{ secrets.GITHUB_NPM_TOKEN }}"
+		}
+	],
 	"lockFileMaintenance": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Overview

- `renovatebot/github-action` は Docker コンテナ内で動くため、ホストの `~/.npmrc` に書いても届かなかった
- `RENOVATE_SECRETS` 環境変数でトークンをコンテナに渡し、`renovate.json` の `hostRules` で参照するように変更した