### PR TITLE
chore(deps): pnpm v11向けにビルドスクリプト許可リストを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 	},
 	"packageManager": "pnpm@10.33.4",
 	"pnpm": {
-		"onlyBuiltDependencies": ["esbuild", "sharp", "workerd"]
+		"onlyBuiltDependencies": [
+			"esbuild",
+			"sharp",
+			"workerd"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.4.12"
 	},
-	"packageManager": "pnpm@10.33.4"
+	"packageManager": "pnpm@10.33.4",
+	"pnpm": {
+		"onlyBuiltDependencies": ["esbuild", "sharp", "workerd"]
+	}
 }


### PR DESCRIPTION
## Overview

- pnpm v11 から、ビルドスクリプトを持つパッケージは明示的な承認が必要になったため、`onlyBuiltDependencies` を追加
- `esbuild`・`sharp`・`workerd` はバイナリのダウンロード・コンパイルにビルドスクリプトが必要なため許可リストに登録
- これにより Renovate の pnpm v11 アップデート PR (#233) がマージ可能になる